### PR TITLE
Check for null result when resolving incidents

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
@@ -222,7 +222,11 @@ public class PagerDutyTrigger extends Notifier{
                 .build();
         try{
             NotifyResult result = pagerDuty.notify(resolution);
-            logger.println("Finished resolving - " + result.status());
+            if (result != null) {
+                logger.println("Finished resolving - " + result.status());
+            } else {
+                logger.println("Attempt to resolve the incident returned null - Incident may already be closed or may not exist.");
+            }
         } catch (IOException e){
             logger.println("Error while trying to resolve ");
             logger.println(e.getMessage());


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-34922

If a PagerDuty incident has already been closed or for some reason does not exist when the PagerDuty plugin attempts to close it, avoid throwing a NullPointerException such as:

```
ERROR: Build step failed with exception
java.lang.NullPointerException
    at org.jenkinsci.plugins.pagerduty.PagerDutyTrigger.resolveIncident(PagerDutyTrigger.java:225)
    at org.jenkinsci.plugins.pagerduty.PagerDutyTrigger.perform(PagerDutyTrigger.java:213)
    at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
    at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:720)
    at hudson.model.Build$BuildExecution.post2(Build.java:185)
    at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:665)
    at hudson.model.Run.execute(Run.java:1766)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:410)
Build step 'PagerDuty Incident Trigger' marked build as failure
```