### PR TITLE
Support adding details to the pager duty incident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
@@ -34,7 +34,6 @@ public class PagerDutyTrigger extends Notifier{
         DO_NOTHING, DO_TRIGGER, DO_RESOLVE
     }
 
-//    private static final Logger LOGG = Logger.getLogger(PagerDutyTrigger.class.getName());
     private static final String DEFAULT_DESCRIPTION_STRING = "I was too lazy to create a description, but trust me it's important!";
 
     public  String serviceKey;
@@ -47,6 +46,7 @@ public class PagerDutyTrigger extends Notifier{
     public  boolean triggerOnNotBuilt;
     public  String incidentKey;
     public  String incDescription;
+    public  String incDetails;
     public  Integer numPreviousBuildsToProbe;
 
     public boolean isResolveOnBackToNormal() { return resolveOnBackToNormal; }
@@ -85,6 +85,10 @@ public class PagerDutyTrigger extends Notifier{
         return incDescription;
     }
 
+    public String getIncDetails() {
+        return incDetails;
+    }
+
     public Integer getNumPreviousBuildsToProbe() {
         return numPreviousBuildsToProbe;
     }
@@ -102,7 +106,7 @@ public class PagerDutyTrigger extends Notifier{
 
     @DataBoundConstructor
     public PagerDutyTrigger(String serviceKey,boolean resolveOnBackToNormal, boolean triggerOnSuccess, boolean triggerOnFailure, boolean triggerOnAborted,
-                            boolean triggerOnUnstable, boolean triggerOnNotBuilt, String incidentKey, String incDescription,
+                            boolean triggerOnUnstable, boolean triggerOnNotBuilt, String incidentKey, String incDescription, String incDetails,
                             Integer numPreviousBuildsToProbe) {
         super();
         this.serviceKey = serviceKey;
@@ -114,6 +118,7 @@ public class PagerDutyTrigger extends Notifier{
         this.triggerOnNotBuilt = triggerOnNotBuilt;
         this.incidentKey = incidentKey;
         this.incDescription = incDescription;
+        this.incDetails = incDetails;
         this.numPreviousBuildsToProbe = (numPreviousBuildsToProbe != null && numPreviousBuildsToProbe > 0) ? numPreviousBuildsToProbe : 1;
     }
 
@@ -246,6 +251,7 @@ public class PagerDutyTrigger extends Notifier{
         String descr = replaceEnvVars(this.incDescription, env, DEFAULT_DESCRIPTION_STRING);
         String serviceK = replaceEnvVars(this.serviceKey, env, null);
         String incK = replaceEnvVars(this.incidentKey, env, null);
+        String details = replaceEnvVars(this.incDetails, env, null);
         boolean hasIncidentKey = false;
 
         if (incK != null && incK.length() > 0) {
@@ -258,10 +264,11 @@ public class PagerDutyTrigger extends Notifier{
             Trigger trigger;
             listener.getLogger().printf("Triggering pagerDuty with incidentKey %s%n", incK);
             listener.getLogger().printf("Triggering pagerDuty with incDescription %s%n", descr);
+            listener.getLogger().printf("Triggering pagerDuty with incDetails %s%n", details);
             if (hasIncidentKey) {
-                trigger = new Trigger.Builder(descr).withIncidentKey(incK).build();
+                trigger = new Trigger.Builder(descr).addDetails("Details", details).withIncidentKey(incK).build();
             } else {
-                trigger = new Trigger.Builder(descr).build();
+                trigger = new Trigger.Builder(descr).addDetails("Details", details).build();
             }
 
             NotifyResult result = pagerDuty.notify(trigger);

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/config.jelly
@@ -10,6 +10,9 @@
   <f:entry title="Incident Description" field="incDescription">
      <f:textbox />
   </f:entry>
+  <f:entry title="Incident Details" field="incDetails">
+     <f:textbox />
+  </f:entry>
   <f:entry title="Number of Consecutive builds before Triggering" field="numPreviousBuildsToProbe">
      <f:textbox default="1"/>
   </f:entry>


### PR DESCRIPTION
Add the ability to add Details to the pager duty incident report.

This allows user to put in the BUILD_URL, for instance, so that when they get a PD alert, they can click on the link and go directly the failing build to get more info.

You can add any env var or string, and it works just fine.