### PR TITLE
Add printing of getErrors() and getMessage()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pagerduty/util/PagerDutyUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/util/PagerDutyUtils.java
@@ -126,6 +126,8 @@ public class PagerDutyUtils {
                     pdparams.incidentKey = result.getIncidentKey();
                 }
                 listener.getLogger().printf("PagerDuty Notification Result: %s%n", result.getStatus());
+                listener.getLogger().printf("Message: %s%n", result.getMessage());
+                listener.getLogger().printf("Errors: %s%n", result.getErrors());
                 listener.getLogger().printf("PagerDuty IncidentKey: <<%s>>%n", pdparams.incidentKey);
             } else {
                 listener.getLogger().printf("PagerDuty returned NULL. check network or PD settings!");


### PR DESCRIPTION
When triggering PagerDuty, the status may be failure, but the logs won't
explain why the error occurred.  This change will print out all information of
the event.