### PR TITLE
set JTH-htmlunit to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
                     <artifactId>jetty-util</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
Fix jenkins-test-harness-htmlunit dependency scope, I guess it was meant to be a test dep.

This change avoids the following libs being included in the plugin hpi file:
```
WEB-INF/lib/commons-collections-3.2.1.jar
WEB-INF/lib/cssparser-0.9.16.jar
WEB-INF/lib/jenkins-test-harness-htmlunit-2.18-1.jar
WEB-INF/lib/nekohtml-1.9.22.jar
WEB-INF/lib/sac-1.3.jar
WEB-INF/lib/serializer-2.7.2.jar
WEB-INF/lib/websocket-api-9.2.12.v20150709.jar
WEB-INF/lib/websocket-client-9.2.12.v20150709.jar
WEB-INF/lib/websocket-common-9.2.12.v20150709.jar
WEB-INF/lib/xalan-2.7.2.jar
WEB-INF/lib/xercesImpl-2.11.0.jar
WEB-INF/lib/xml-apis-1.4.01.jar
```
