### PR TITLE
Upgrade to pagerduty-client 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+#IntelliJ
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
         <relativePath />
     </parent>
     <artifactId>pagerduty</artifactId>
-    <version>0.4.2-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <java.level>8</java.level>
         <jetty.version>9.4.17.v20190418</jetty.version>
-        <jenkins.version>2.54</jenkins.version>
+        <jenkins.version>2.164</jenkins.version>
         <mavenVersion>3.3.9</mavenVersion>
     </properties>
     <name>PagerDuty Plugin</name>
@@ -56,13 +56,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.7</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
-                <scope>test</scope>
+                <version>2.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -70,7 +68,7 @@
         <dependency>
             <groupId>com.github.dikhan</groupId>
             <artifactId>pagerduty-client</artifactId>
-            <version>2.0.4</version>
+            <version>3.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/PDConstants.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/PDConstants.java
@@ -3,13 +3,7 @@ package org.jenkinsci.plugins.pagerduty;
 /**
  * Created by alex on 10/07/17.
  */
-public class PDConstants {
-
-    public static final String JENKINS_PD_CLIENT = "JenkinsPagerDutyClient";
-    public static final String DEFAULT_RESOLVE_STR = "Automatically Resolved by PD plugin";
-    public static final String DEFAULT_RESOLVE_DESC = "Resolved by PD plugin";
-    public static final String DEFAULT_DESCRIPTION_STRING = "I was too lazy to create a description, but trust me it's important!";
-
+class PDConstants {
     public enum ValidationResult {
         DO_NOTHING, DO_TRIGGER, DO_RESOLVE
     }

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyParamHolder.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyParamHolder.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pagerduty;
 
+import com.github.dikhan.pagerduty.client.events.domain.Severity;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
@@ -14,61 +15,112 @@ import java.io.IOException;
  */
 public class PagerDutyParamHolder {
 
-    private String serviceKey;
-    private String incidentKey;
-    private String incDescription;
-    private String incDetails;
+    private String routingKey;
+    private String dedupKey;
+    private String incidentSummary;
+    private String incidentSource;
+    private String incidentSeverity;
+    private String incidentComponent;
+    private String incidentGroup;
+    private String incidentClass;
 
-    public PagerDutyParamHolder(String serviceKey, String incidentKey, String incDescription, String incDetails) {
-        this.serviceKey = serviceKey;
-        this.incDescription = incDescription;
-        this.incidentKey = incidentKey;
-        this.incDetails = incDetails;
+    public PagerDutyParamHolder(String routingKey, String dedupKey, String incidentSummary, String incidentSource, String incidentSeverity, String incidentComponent, String incidentGroup, String incidentClass) {
+        this.routingKey = routingKey;
+        this.dedupKey = dedupKey;
+        this.incidentSummary = incidentSummary;
+        this.incidentSource = incidentSource;
+        this.incidentSeverity = incidentSeverity;
+        this.incidentComponent = incidentComponent;
+        this.incidentGroup = incidentGroup;
+        this.incidentClass = incidentClass;
     }
 
-    public String getServiceKey() {
-        return serviceKey;
+    public String getRoutingKey() {
+        return routingKey;
     }
 
-    public void setServiceKey(String serviceKey) {
-        this.serviceKey = serviceKey;
+    public void setRoutingKey(String routingKey) {
+        this.routingKey = routingKey;
     }
 
-    public String getIncidentKey() {
-        return incidentKey;
+    public String getDedupKey() {
+        return dedupKey;
     }
 
-    public void setIncidentKey(String incidentKey) {
-        this.incidentKey = incidentKey;
+    public void setDedupKey(String dedupKey) {
+        this.dedupKey = dedupKey;
     }
 
-    public String getIncDescription() {
-        return incDescription;
+    public String getIncidentSummary() {
+        return incidentSummary;
     }
 
-    public void setIncDescription(String incDescription) {
-        this.incDescription = incDescription;
+    public void setIncidentSummary(String incidentSummary) {
+        this.incidentSummary = incidentSummary;
     }
 
-    public String getIncDetails() {
-        return incDetails;
+    public String getIncidentSource() {
+        return incidentSource;
     }
 
-    public void setIncDetails(String incDetails) {
-        this.incDetails = incDetails;
+    public void setIncidentSource(String incidentSource) {
+        this.incidentSource = incidentSource;
+    }
+
+    public Severity getIncidentSeverity() {
+        if (incidentSeverity != null && !incidentSeverity.isEmpty()) {
+            return Severity.valueOf(incidentSeverity.toUpperCase());
+        }
+        return Severity.CRITICAL;
+    }
+
+    public void setIncidentSeverity(String incidentSeverity) {
+        this.incidentSeverity = incidentSeverity;
+    }
+
+    public String getIncidentComponent() {
+        return incidentComponent;
+    }
+
+    public void setIncidentComponent(String incidentComponent) {
+        this.incidentComponent = incidentComponent;
+    }
+
+    public String getIncidentGroup() {
+        return incidentGroup;
+    }
+
+    public void setIncidentGroup(String incidentGroup) {
+        this.incidentGroup = incidentGroup;
+    }
+
+    public String getIncidentClass() {
+        return incidentClass;
+    }
+
+    public void setIncidentClass(String incidentClass) {
+        this.incidentClass = incidentClass;
     }
 
     public void tokenReplaceWorkflow(Run<?, ?> run, FilePath workspace, TaskListener listener) throws InterruptedException, MacroEvaluationException, IOException {
-        this.setIncDescription(TokenMacro.expandAll(run, workspace, listener, this.incDescription));
-        this.setServiceKey(TokenMacro.expandAll(run, workspace, listener, this.serviceKey));
-        this.setIncidentKey(TokenMacro.expandAll(run, workspace, listener, this.incidentKey));
-        this.setIncDetails(TokenMacro.expandAll(run, workspace, listener, this.incDetails));
+        this.setRoutingKey(TokenMacro.expandAll(run, workspace, listener, this.routingKey));
+        this.setDedupKey(TokenMacro.expandAll(run, workspace, listener, this.dedupKey));
+        this.setIncidentSummary(TokenMacro.expandAll(run, workspace, listener, this.incidentSummary));
+        this.setIncidentSource(TokenMacro.expandAll(run, workspace, listener, this.incidentSource));
+        this.setIncidentSeverity(TokenMacro.expandAll(run, workspace, listener, this.incidentSeverity));
+        this.setIncidentComponent(TokenMacro.expandAll(run, workspace, listener, this.incidentComponent));
+        this.setIncidentGroup(TokenMacro.expandAll(run, workspace, listener, this.incidentGroup));
+        this.setIncidentClass(TokenMacro.expandAll(run, workspace, listener, this.incidentClass));
     }
 
     public void tokenReplace(AbstractBuild<?, ?> build, TaskListener listener) throws InterruptedException, MacroEvaluationException, IOException {
-        this.setIncDescription(TokenMacro.expandAll(build, listener, this.incDescription));
-        this.setServiceKey(TokenMacro.expandAll(build, listener, this.serviceKey));
-        this.setIncidentKey(TokenMacro.expandAll(build, listener, this.incidentKey));
-        this.setIncDetails(TokenMacro.expandAll(build, listener, this.incDetails));
+        this.setRoutingKey(TokenMacro.expandAll(build, listener, this.routingKey));
+        this.setDedupKey(TokenMacro.expandAll(build, listener, this.dedupKey));
+        this.setIncidentSummary(TokenMacro.expandAll(build, listener, this.incidentSummary));
+        this.setIncidentSource(TokenMacro.expandAll(build, listener, this.incidentSource));
+        this.setIncidentSeverity(TokenMacro.expandAll(build, listener, this.incidentSeverity));
+        this.setIncidentComponent(TokenMacro.expandAll(build, listener, this.incidentComponent));
+        this.setIncidentGroup(TokenMacro.expandAll(build, listener, this.incidentGroup));
+        this.setIncidentClass(TokenMacro.expandAll(build, listener, this.incidentClass));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
@@ -2,7 +2,10 @@ package org.jenkinsci.plugins.pagerduty;
 
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
@@ -20,34 +23,75 @@ import java.util.List;
  */
 public class PagerDutyTrigger extends Notifier {
 
-    private String serviceKey;
+    private String routingKey;
+    private String dedupKey;
+    private String incidentSummary;
+    private String incidentSource;
+    private String incidentSeverity;
+    private String incidentComponent;
+    private String incidentGroup;
+    private String incidentClass;
+    private Integer numPreviousBuildsToProbe;
     private boolean resolveOnBackToNormal;
     private boolean triggerOnSuccess;
     private boolean triggerOnFailure;
     private boolean triggerOnUnstable;
     private boolean triggerOnAborted;
     private boolean triggerOnNotBuilt;
-    private String incidentKey;
-    private String incDescription;
-    private String incDetails;
-    private Integer numPreviousBuildsToProbe;
 
     @DataBoundConstructor
-    public PagerDutyTrigger(String serviceKey, boolean resolveOnBackToNormal, boolean triggerOnSuccess, boolean triggerOnFailure, boolean triggerOnAborted,
-                            boolean triggerOnUnstable, boolean triggerOnNotBuilt, String incidentKey, String incDescription, String incDetails,
+    public PagerDutyTrigger(String routingKey, String dedupKey, String incidentSummary, String incidentSource,
+                            String incidentSeverity, String incidentComponent, String incidentGroup,
+                            String incidentClass, boolean triggerOnSuccess, boolean triggerOnFailure,
+                            boolean triggerOnUnstable, boolean triggerOnAborted, boolean triggerOnNotBuilt,
                             Integer numPreviousBuildsToProbe) {
         super();
-        this.serviceKey = serviceKey;
-        this.resolveOnBackToNormal = resolveOnBackToNormal;
+        this.routingKey = routingKey;
+        this.dedupKey = dedupKey;
+        this.incidentSummary = incidentSummary;
+        this.incidentSource = incidentSource;
+        this.incidentSeverity = incidentSeverity;
+        this.incidentComponent = incidentComponent;
+        this.incidentGroup = incidentGroup;
+        this.incidentClass = incidentClass;
         this.triggerOnSuccess = triggerOnSuccess;
         this.triggerOnFailure = triggerOnFailure;
         this.triggerOnUnstable = triggerOnUnstable;
         this.triggerOnAborted = triggerOnAborted;
         this.triggerOnNotBuilt = triggerOnNotBuilt;
-        this.incidentKey = incidentKey;
-        this.incDescription = incDescription;
-        this.incDetails = incDetails;
         this.numPreviousBuildsToProbe = (numPreviousBuildsToProbe != null && numPreviousBuildsToProbe > 0) ? numPreviousBuildsToProbe : 1;
+    }
+
+    public String getRoutingKey() {
+        return routingKey;
+    }
+
+    public String getDedupKey() {
+        return dedupKey;
+    }
+
+    public String getIncidentSummary() {
+        return incidentSummary;
+    }
+
+    public String getIncidentSource() {
+        return incidentSource;
+    }
+
+    public String getIncidentSeverity() {
+        return incidentSeverity;
+    }
+
+    public String getIncidentComponent() {
+        return incidentComponent;
+    }
+
+    public String getIncidentGroup() {
+        return incidentGroup;
+    }
+
+    public String getIncidentClass() {
+        return incidentClass;
     }
 
     public boolean isResolveOnBackToNormal() {
@@ -58,8 +102,8 @@ public class PagerDutyTrigger extends Notifier {
         this.resolveOnBackToNormal = resolveOnBackToNormal;
     }
 
-    public String getServiceKey() {
-        return serviceKey;
+    public Integer getNumPreviousBuildsToProbe() {
+        return numPreviousBuildsToProbe;
     }
 
     public boolean isTriggerOnSuccess() {
@@ -80,22 +124,6 @@ public class PagerDutyTrigger extends Notifier {
 
     public boolean isTriggerOnNotBuilt() {
         return triggerOnNotBuilt;
-    }
-
-    public String getIncidentKey() {
-        return incidentKey;
-    }
-
-    public String getIncDescription() {
-        return incDescription;
-    }
-
-    public String getIncDetails() {
-        return incDetails;
-    }
-
-    public Integer getNumPreviousBuildsToProbe() {
-        return numPreviousBuildsToProbe;
     }
 
     protected Object readResolve() {
@@ -171,23 +199,22 @@ public class PagerDutyTrigger extends Notifier {
 
         boolean res = true;
         PDConstants.ValidationResult validationResult = validWithPreviousResults(build, resultProbe, this.numPreviousBuildsToProbe);
-        PagerDutyParamHolder pdparams = new PagerDutyParamHolder(serviceKey, incidentKey, incDescription, incDetails);
+        PagerDutyParamHolder pdparams = new PagerDutyParamHolder(routingKey, dedupKey, incidentSummary,
+                incidentSource, incidentSeverity, incidentComponent, incidentGroup, incidentClass);
         if (validationResult != PDConstants.ValidationResult.DO_NOTHING) {
             if (validationResult == PDConstants.ValidationResult.DO_TRIGGER) {
                 listener.getLogger().println("Triggering PagerDuty Notification");
-//                return triggerPagerDuty(listener, env, pagerDutyEventsClient);
                 res = PagerDutyUtils.triggerPagerDuty(pdparams, build, null, listener);
-                this.incidentKey = pdparams.getIncidentKey();
+                this.dedupKey = pdparams.getDedupKey();
             } else if (validationResult == PDConstants.ValidationResult.DO_RESOLVE) {
-                // listener.getLogger().println(build.getPreviousFailedBuild().getLog());
-                if (this.incidentKey == null || this.incidentKey.isEmpty()) {
+                if (this.dedupKey == null || this.dedupKey.isEmpty()) {
                     AbstractBuild<?, ?> prevBuild = build.getPreviousFailedBuild();
                     if (prevBuild != null) {
-                        String llog = prevBuild.getLog();
-                        this.incidentKey = PagerDutyUtils.extractIncidentKey(llog);
+                        String log = prevBuild.getLog();
+                        this.dedupKey = PagerDutyUtils.extractDedupKey(log);
                     }
                 }
-                pdparams.setIncidentKey(this.incidentKey);
+                pdparams.setDedupKey(this.dedupKey);
                 listener.getLogger().println("Resolving incident");
                 res = PagerDutyUtils.resolveIncident(pdparams, build, listener);
             }

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger.java
@@ -42,9 +42,9 @@ public class PagerDutyTrigger extends Notifier {
     @DataBoundConstructor
     public PagerDutyTrigger(String routingKey, String dedupKey, String incidentSummary, String incidentSource,
                             String incidentSeverity, String incidentComponent, String incidentGroup,
-                            String incidentClass, boolean triggerOnSuccess, boolean triggerOnFailure,
-                            boolean triggerOnUnstable, boolean triggerOnAborted, boolean triggerOnNotBuilt,
-                            Integer numPreviousBuildsToProbe) {
+                            String incidentClass, boolean resolveOnBackToNormal, boolean triggerOnSuccess,
+                            boolean triggerOnFailure, boolean triggerOnUnstable, boolean triggerOnAborted,
+                            boolean triggerOnNotBuilt, Integer numPreviousBuildsToProbe) {
         super();
         this.routingKey = routingKey;
         this.dedupKey = dedupKey;
@@ -54,6 +54,7 @@ public class PagerDutyTrigger extends Notifier {
         this.incidentComponent = incidentComponent;
         this.incidentGroup = incidentGroup;
         this.incidentClass = incidentClass;
+        this.resolveOnBackToNormal = resolveOnBackToNormal;
         this.triggerOnSuccess = triggerOnSuccess;
         this.triggerOnFailure = triggerOnFailure;
         this.triggerOnUnstable = triggerOnUnstable;

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyTriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyTriggerStep.java
@@ -27,20 +27,24 @@ import javax.inject.Inject;
 public class PagerDutyTriggerStep extends AbstractStepImpl {
 
     @Nonnull
-    private final String serviceKey;
+    private final String routingKey;
     private boolean resolve;
-    private String incidentKey;
-    private String incDescription;
-    private String incDetails;
+    private String dedupKey;
+    private String incidentSummary;
+    private String incidentSource;
+    private String incidentSeverity;
+    private String incidentComponent;
+    private String incidentGroup;
+    private String incidentClass;
 
     @DataBoundConstructor
-    public PagerDutyTriggerStep(@Nonnull String serviceKey) {
-        this.serviceKey = serviceKey;
+    public PagerDutyTriggerStep(@Nonnull String routingKey) {
+        this.routingKey = routingKey;
     }
 
     @Nonnull
-    public String getServiceKey() {
-        return serviceKey;
+    public String getRoutingKey() {
+        return routingKey;
     }
 
     @DataBoundSetter
@@ -52,31 +56,67 @@ public class PagerDutyTriggerStep extends AbstractStepImpl {
         return resolve;
     }
 
-    public String getIncidentKey() {
-        return incidentKey;
+    public String getDedupKey() {
+        return dedupKey;
     }
 
     @DataBoundSetter
-    public void setIncidentKey(String incidentKey) {
-        this.incidentKey = incidentKey;
+    public void setDedupKey(String dedupKey) {
+        this.dedupKey = dedupKey;
     }
 
-    public String getIncDescription() {
-        return incDescription;
-    }
-
-    @DataBoundSetter
-    public void setIncDescription(String incDescription) {
-        this.incDescription = incDescription;
-    }
-
-    public String getIncDetails() {
-        return incDetails;
+    public String getIncidentSummary() {
+        return incidentSummary;
     }
 
     @DataBoundSetter
-    public void setIncDetails(String incDetails) {
-        this.incDetails = incDetails;
+    public void setIncidentSummary(String incidentSummary) {
+        this.incidentSummary = incidentSummary;
+    }
+
+    public String getIncidentSource() {
+        return incidentSource;
+    }
+
+    @DataBoundSetter
+    public void setIncidentSource(String incidentSource) {
+        this.incidentSource = incidentSource;
+    }
+
+    public String getIncidentSeverity() {
+        return incidentSeverity;
+    }
+
+    @DataBoundSetter
+    public void setIncidentSeverity(String incidentSeverity) {
+        this.incidentSeverity = incidentSeverity;
+    }
+
+    public String getIncidentComponent() {
+        return incidentComponent;
+    }
+
+    @DataBoundSetter
+    public void setIncidentComponent(String incidentComponent) {
+        this.incidentComponent = incidentComponent;
+    }
+
+    public String getIncidentGroup() {
+        return incidentGroup;
+    }
+
+    @DataBoundSetter
+    public void setIncidentGroup(String incidentGroup) {
+        this.incidentGroup = incidentGroup;
+    }
+
+    public String getIncidentClass() {
+        return incidentClass;
+    }
+
+    @DataBoundSetter
+    public void setIncidentClass(String incidentClass) {
+        this.incidentClass = incidentClass;
     }
 
     @Extension
@@ -125,15 +165,16 @@ public class PagerDutyTriggerStep extends AbstractStepImpl {
                 listener.getLogger().println("Desc Exists");
             }
 
-            PagerDutyParamHolder pdparams = new PagerDutyParamHolder(step.serviceKey, step.incidentKey, step.incDescription, step.incDetails);
+            PagerDutyParamHolder pdparams = new PagerDutyParamHolder(step.routingKey, step.dedupKey, step.incidentSummary,
+                    step.incidentSource, step.incidentSeverity, step.incidentComponent, step.incidentGroup, step.incidentClass);
 
-            if (step.resolve == true) {
+            if (step.resolve) {
                 PagerDutyUtils.resolveIncident(pdparams, this.getContext().get(AbstractBuild.class), listener);
             } else {
                 PagerDutyUtils.triggerPagerDuty(pdparams, run, getContext().get(FilePath.class), listener);
             }
 
-            return pdparams.getIncidentKey();
+            return pdparams.getDedupKey();
         }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/config.jelly
@@ -1,16 +1,33 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
                  xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="Service Integration Key" field="serviceKey">
+  <f:entry title="Routing Key" field="routingKey">
     <f:textbox />
   </f:entry>
-  <f:entry title="incidentKey" field="incidentKey">
+  <f:entry title="Dedup Key" field="dedupKey">
     <f:textbox />
   </f:entry>
-  <f:entry title="Incident Description" field="incDescription">
+  <f:entry title="Summary" field="incidentSummary">
      <f:textbox />
   </f:entry>
-  <f:entry title="Incident Details" field="incDetails">
+  <f:entry title="Source" field="incidentSource">
+     <f:textbox />
+  </f:entry>
+  <f:entry title="Severity" field="incidentSeverity">
+     <select>
+       <option value="critical">Critical</option>
+       <option value="error">Error</option>
+       <option value="warning">Warning</option>
+       <option value="info">Info</option>
+     </select>
+  </f:entry>
+  <f:entry title="Component" field="incidentComponent">
+     <f:textbox />
+  </f:entry>
+  <f:entry title="Group" field="incidentGroup">
+     <f:textbox />
+  </f:entry>
+  <f:entry title="Class" field="incidentClass">
      <f:textbox />
   </f:entry>
   <f:entry title="Number of Consecutive builds before Triggering" field="numPreviousBuildsToProbe">

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-dedupKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-dedupKey.html
@@ -1,0 +1,3 @@
+<div>
+    Deduplication key for correlating triggers and resolves. The maximum permitted length of this property is 255 characters.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incDescription.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incDescription.html
@@ -1,3 +1,0 @@
-<div>
-    Description of the triggered incident.
-</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentClass.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentClass.html
@@ -1,0 +1,3 @@
+<div>
+    The class/type of the event, for example ping failure or cpu load.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentComponent.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentComponent.html
@@ -1,0 +1,3 @@
+<div>
+    Component of the source machine that is responsible for the event, for example mysql or eth0.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentGroup.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentGroup.html
@@ -1,0 +1,3 @@
+<div>
+    Logical grouping of components of a service, for example app-stack.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentKey.html
@@ -1,3 +1,0 @@
-<div>
-    PagerDuty incident id if available (otherwise it will create one).
-</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentSource.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentSource.html
@@ -1,0 +1,3 @@
+<div>
+    The unique location of the affected system, preferably a hostname or FQDN.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentSummary.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-incidentSummary.html
@@ -1,0 +1,3 @@
+<div>
+    A brief text summary of the event, used to generate the summaries/titles of any associated alerts. The maximum permitted length of this property is 1024 characters.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-routingKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-routingKey.html
@@ -1,0 +1,3 @@
+<div>
+    PagerDuty 32 character Integration Key for an integration on a service or on a global ruleset.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-serviceKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help-serviceKey.html
@@ -1,5 +1,0 @@
-<div>
-    The service integration Key of your PagerDuty account.
-    The service key will allow you to trigger incidents on a specific service.
-    (Don't mix with the API key, it serves different purposes)
-</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/PagerDutyTrigger/help.html
@@ -1,3 +1,3 @@
 <div>
-    Trigger PagerDuty incident on failed job.
+    Trigger or resolve PagerDuty incident on failed job.
 </div>


### PR DESCRIPTION
In order to use the new fields provided by PagerDuty Events API v2, I have upgraded the pagerduty-client dependency to 3.0.8.

This version is not compatible anymore with the previous PagerDuty plugin has the form is completely changing to comply with the new Events API v2:
<img width="888" alt="Screenshot 2020-07-16 at 17 11 01" src="https://user-images.githubusercontent.com/8882/87696286-e3d7a500-c790-11ea-89ef-8f4cbb32a488.png">

In addition, I have added the proxy support provided by the latest version of pagerduty-client.