### PR TITLE
[JENKINS-64198] Add support for PagerDuty Change Events.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ hs_err_pid*
 
 #IntelliJ
 .idea
+
+# Where files are stored when running the development server
+work/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Jenkins PagerDuty Plugin
 
-Jenkins plugin that allows triggering [PagerDuty](https://www.pagerduty.com/) incidents as post-build action or pipeline step.
+This plugin provides two post-build actions/pipeline steps for interacting with the [PagerDuty](https://www.pagerduty.com/) platform.
+
+## Trigger/Resolve Incidents
+
+Using the "PagerDuty Incident Trigger" action, you can trigger or resolve incidents based on the results of a job.
+
+## Create Change Events
+
+Using the "PagerDuty Change Events" action, you can create a [change event](https://support.pagerduty.com/docs/change-events) when a job completes.
+
+## Getting Started
+
+Before you can use this plugin you'll need an integration key (also known as a routing key). This key tells PagerDuty which service the incoming event should be sent to. If you already have a service in PagerDuty you can [add an integration to it](https://support.pagerduty.com/docs/services-and-integrations#add-integrations-to-an-existing-service); otherwise, you can add the integration when [creating a new service](https://support.pagerduty.com/docs/services-and-integrations#create-a-new-service). For the integration type, choose "Jenkins CI".
+
+Once you have an integration key you can add the appropriate action to your Jenkins project and supply it with the integration key. Be sure to select which job results you want to send an event to PagerDuty.
 
 [![Gitter](https://badges.gitter.im/jenkinsci/pagerduty-plugin.svg)](https://gitter.im/jenkinsci/pagerduty-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
         <relativePath />
     </parent>
     <artifactId>pagerduty</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <java.level>8</java.level>
         <jetty.version>9.4.17.v20190418</jetty.version>
-        <jenkins.version>2.164</jenkins.version>
+        <jenkins.version>2.176.4</jenkins.version>
         <mavenVersion>3.3.9</mavenVersion>
     </properties>
     <name>PagerDuty Plugin</name>
@@ -79,6 +79,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
             <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>display-url-api</artifactId>
+            <version>2.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvent.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvent.java
@@ -1,0 +1,186 @@
+package org.jenkinsci.plugins.pagerduty.changeevents;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Represents the data that can be provided to the Change Events API.
+ *
+ * See https://developer.pagerduty.com/docs/events-api-v2/send-change-events/
+ */
+public class ChangeEvent {
+    /**
+     * The integration key that identifies the service the change occurred on.
+     */
+    private String integrationKey;
+
+    /**
+     * A description of what changed.
+     */
+    private String summary;
+
+    /**
+     * The source of the change.
+     */
+    private String source;
+
+    /**
+     * When the change occurred.
+     */
+    private Date timestamp;
+
+    /**
+     * Additional information about the change.
+     */
+    private HashMap<String, ?> customDetails;
+
+    /**
+     * Links related to the change.
+     */
+    private List<Link> links;
+
+    public ChangeEvent() {
+        this.source = "Jenkins";
+        this.timestamp = new Date();
+        this.customDetails = new HashMap<>();
+        this.links = new ArrayList<>();
+    }
+
+    public String getIntegrationKey() {
+        return integrationKey;
+    }
+
+    public void setIntegrationKey(String integrationKey) {
+        this.integrationKey = integrationKey;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(@Nonnull String summary) {
+        this.summary = summary;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public Date getTimestamp() {
+        return (Date) timestamp.clone();
+    }
+
+    public void setTimestamp(@Nonnull Date timestamp) {
+        this.timestamp = (Date) timestamp.clone();
+    }
+
+    public HashMap<String, ?> getCustomDetails() {
+        return customDetails;
+    }
+
+    public void setCustomDetails(HashMap<String, ?> customDetails) {
+        this.customDetails = customDetails;
+    }
+
+    public List<Link> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    /**
+     * Represents a link on a change event.
+     */
+    public static final class Link {
+        /**
+         * The target of the link.
+         */
+        private String href;
+
+        /**
+         * Descriptive text for the link.
+         */
+        private String text;
+
+        public Link(String href) {
+            this.href = href;
+        }
+
+        public Link(String href, String text) {
+            this.href = href;
+            this.text = text;
+        }
+
+        public String getHref() {
+            return href;
+        }
+
+        public void setHref(String href) {
+            this.href = href;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+    }
+
+    /**
+     * Provides convenience functions for building a change event.
+     */
+    public static final class Builder {
+        private final ChangeEvent changeEvent;
+
+        public Builder() {
+            this.changeEvent = new ChangeEvent();
+        }
+
+        public Builder setIntegrationKey(String integrationKey) {
+            changeEvent.setIntegrationKey(integrationKey);
+            return this;
+        }
+
+        public Builder setSummary(String summary) {
+            changeEvent.setSummary(summary);
+            return this;
+        }
+
+        public Builder setSource(String source) {
+            changeEvent.setSource(source);
+            return this;
+        }
+
+        public Builder setTimestamp(Date timestamp) {
+            changeEvent.setTimestamp(timestamp);
+            return this;
+        }
+
+        public Builder setCustomDetails(HashMap<String, ?> customDetails) {
+            changeEvent.setCustomDetails(customDetails);
+            return this;
+        }
+
+        public Builder addLink(Link link) {
+            List<Link> links = changeEvent.getLinks();
+            links.add(link);
+            changeEvent.setLinks(links);
+            return this;
+        }
+
+        public ChangeEvent build() {
+            return changeEvent;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventSender.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventSender.java
@@ -1,0 +1,122 @@
+package org.jenkinsci.plugins.pagerduty.changeevents;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.model.Cause;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Orchestrates generating a Change Event from the details of a build and sends
+ * it to PagerDuty.
+ */
+public class ChangeEventSender {
+    public final void send(String integrationKey, Run<?, ?> build, TaskListener listener) {
+        try {
+            ChangeEvent changeEvent = getChangeEvent(integrationKey, build);
+            String json = convertToJSON(changeEvent);
+
+            listener.getLogger().println("Generated payload for PagerDuty Change Events");
+            listener.getLogger().println(json);
+
+            ChangeEventsAPI.Response response = ChangeEventsAPI.send(json);
+            listener.getLogger().println("PagerDuty Change Events responded with " + response.getCode());
+            listener.getLogger().println(response.getBody());
+        } catch (IOException e) {
+            e.printStackTrace(listener.error(e.getMessage()));
+        }
+    }
+
+    private ChangeEvent getChangeEvent(String integrationKey, Run<?, ?> build) {
+        String summary = getSummary(build);
+        HashMap<String, ?> customDetails = getCustomDetails(build);
+        ChangeEvent.Link buildLink = getBuildLink(build);
+
+        return new ChangeEvent.Builder().setIntegrationKey(integrationKey).setSummary(summary)
+                .setTimestamp(build.getTime()).setCustomDetails(customDetails).addLink(buildLink).build();
+    }
+
+    private String getSummary(Run<?, ?> build) {
+        String message = build.getFullDisplayName();
+        Result result = build.getResult();
+
+        if (build.getDescription() != null) {
+            message = message + build.getDescription();
+        }
+
+        if (result != null) {
+            message = message + ": " + result.toString();
+        }
+
+        return message;
+    }
+
+    private HashMap<String, ?> getCustomDetails(Run<?, ?> build) {
+        HashMap<String, Object> customDetails = new HashMap<>();
+        Result result = build.getResult();
+
+        if (build.getDescription() != null) {
+            customDetails.put("description", build.getDescription());
+        }
+
+        customDetails.put("duration", build.getDurationString());
+        customDetails.put("build_number", build.getNumber());
+
+        if (result != null) {
+            customDetails.put("result", result.toString());
+        }
+
+        if (!build.getCauses().isEmpty()) {
+            Cause cause = build.getCauses().get(0);
+            customDetails.put("cause", cause.getShortDescription());
+        }
+
+        return customDetails;
+    }
+
+    private ChangeEvent.Link getBuildLink(Run<?, ?> build) {
+        return new ChangeEvent.Link(DisplayURLProvider.get().getRunURL(build), "View on Jenkins");
+    }
+
+    private String convertToJSON(ChangeEvent changeEvent) throws JsonProcessingException {
+        TimeZone timeZone = TimeZone.getTimeZone("UTC");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S'Z'");
+        dateFormat.setTimeZone(timeZone);
+
+        HashMap<String, Object> payload = new HashMap<>();
+        payload.put("summary", changeEvent.getSummary());
+        payload.put("source", changeEvent.getSource());
+        payload.put("timestamp", dateFormat.format(changeEvent.getTimestamp()));
+        payload.put("custom_details", changeEvent.getCustomDetails());
+
+        List<HashMap<String, String>> links = new ArrayList<>();
+        changeEvent.getLinks().forEach((link) -> {
+            HashMap<String, String> linkMap = new HashMap<>();
+            linkMap.put("href", link.getHref());
+
+            if (link.getText() != null) {
+                linkMap.put("text", link.getText());
+            }
+
+            links.add(linkMap);
+        });
+
+        HashMap<String, Object> event = new HashMap<>();
+        event.put("routing_key", changeEvent.getIntegrationKey());
+        event.put("payload", payload);
+        event.put("links", links);
+
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(event);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents.java
@@ -1,0 +1,170 @@
+package org.jenkinsci.plugins.pagerduty.changeevents;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A build step for recording a PagerDuty Change Event.
+ *
+ * This is intended to be used as a post-build action. It takes details from the
+ * build and makes an API call to PagerDuty's Change Events API.
+ *
+ * See https://developer.pagerduty.com/docs/events-api-v2/send-change-events/
+ */
+public class ChangeEvents extends Notifier implements SimpleBuildStep {
+    /**
+     * The integration key that identifies the service the change occurred on.
+     */
+    private final String integrationKey;
+
+    /**
+     * Should a change event be created on successful builds.
+     */
+    private boolean createOnSuccess;
+
+    /**
+     * Should a change event be created on failed builds.
+     */
+    private boolean createOnFailure;
+
+    /**
+     * Should a change event be created on unstable builds.
+     */
+    private boolean createOnUnstable;
+
+    /**
+     * Should a change event be created on aborted builds.
+     */
+    private boolean createOnAborted;
+
+    /**
+     * Should a change event be created on not built builds.
+     */
+    private boolean createOnNotBuilt;
+
+    @DataBoundConstructor
+    public ChangeEvents(String integrationKey) {
+        this.integrationKey = integrationKey;
+    }
+
+    @Override
+    public void perform(Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+            @Nonnull TaskListener listener) {
+        Result result = build.getResult();
+
+        if ((result == Result.SUCCESS && createOnSuccess) || (result == Result.FAILURE && createOnFailure)
+                || (result == Result.UNSTABLE && createOnUnstable) || (result == Result.ABORTED && createOnAborted)
+                || (result == Result.NOT_BUILT && createOnNotBuilt)) {
+            new ChangeEventSender().send(integrationKey, build, listener);
+        }
+
+    }
+
+    public static DescriptorImpl descriptor() {
+        return Jenkins.get().getDescriptorByType(ChangeEvents.DescriptorImpl.class);
+    }
+
+    public String getIntegrationKey() {
+        return integrationKey;
+    }
+
+    public boolean getCreateOnSuccess() {
+        return createOnSuccess;
+    }
+
+    @DataBoundSetter
+    public void setCreateOnSuccess(boolean createOnSuccess) {
+        this.createOnSuccess = createOnSuccess;
+    }
+
+    public boolean getCreateOnFailure() {
+        return createOnFailure;
+    }
+
+    @DataBoundSetter
+    public void setCreateOnFailure(boolean createOnFailure) {
+        this.createOnFailure = createOnFailure;
+    }
+
+    public boolean getCreateOnUnstable() {
+        return createOnUnstable;
+    }
+
+    @DataBoundSetter
+    public void setCreateOnUnstable(boolean createOnUnstable) {
+        this.createOnUnstable = createOnUnstable;
+    }
+
+    public boolean getCreateOnAborted() {
+        return createOnAborted;
+    }
+
+    @DataBoundSetter
+    public void setCreateOnAborted(boolean createOnAborted) {
+        this.createOnAborted = createOnAborted;
+    }
+
+    public boolean getCreateOnNotBuilt() {
+        return createOnNotBuilt;
+    }
+
+    @DataBoundSetter
+    public void setCreateOnNotBuilt(boolean createOnNotBuilt) {
+        this.createOnNotBuilt = createOnNotBuilt;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        @Nonnull
+        public String getDisplayName() {
+            return "PagerDuty Change Events";
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
+
+        /**
+         * Provides basic validation of integration keys.
+         *
+         * Just ensures they are the correct length and only include allowed characters.
+         *
+         * @param value The integration key
+         * @return Whether or not the integration key is valid
+         */
+        public FormValidation doCheckIntegrationKey(@QueryParameter String value) {
+            Pattern pattern = Pattern.compile("^[0-9a-z]{32}$");
+            Matcher matcher = pattern.matcher(value);
+
+            if (matcher.matches()) {
+                return FormValidation.ok();
+            }
+
+            if (value.length() != 32) {
+                return FormValidation.error("Must be 32 characters long");
+            }
+
+            return FormValidation.error("Must only be letters and digits");
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventsAPI.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventsAPI.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.plugins.pagerduty.changeevents;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.stream.Collectors;
+
+/**
+ * Simple wrapper around calling the PagerDuty Change Events API.
+ */
+public class ChangeEventsAPI {
+    public static Response send(String json) throws IOException {
+        URL url = new URL("https://events.pagerduty.com/v2/change/enqueue");
+
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        connection.setRequestProperty("content-type", "application/json");
+
+        try (OutputStream out = connection.getOutputStream(); Writer writer = new OutputStreamWriter(out, "UTF-8")) {
+            writer.write(json);
+        }
+
+        String body;
+
+        try (InputStream responseStream = connection.getInputStream();
+                Reader reader = new InputStreamReader(responseStream, "UTF-8");
+                BufferedReader bufferedReader = new BufferedReader(reader)) {
+            body = bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
+        }
+
+        return new Response(connection.getResponseCode(), body);
+    }
+
+    public static final class Response {
+        private final int code;
+
+        private final String body;
+
+        public Response(int code, String body) {
+            this.code = code;
+            this.body = body;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public String getBody() {
+            return body;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyChangeEventStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyChangeEventStep.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.pagerduty.pipeline;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.jenkinsci.plugins.pagerduty.changeevents.ChangeEventSender;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+/**
+ * Workflow step for creating a PagerDuty Change Event.
+ */
+public class PagerDutyChangeEventStep {
+  @Nonnull
+  private final String integrationKey;
+
+  @DataBoundConstructor
+  public PagerDutyChangeEventStep(@Nonnull String integrationKey) {
+    this.integrationKey = integrationKey;
+  }
+
+  @Nonnull
+  public String getIntegrationKey() {
+    return integrationKey;
+  }
+
+  @Extension
+  public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+    public DescriptorImpl() {
+      super(PagerDutyChangeEventExecution.class);
+    }
+
+    @Override
+    public String getFunctionName() {
+      return "pagerdutyChangeEvent";
+    }
+
+    @Override
+    public String getDisplayName() {
+      return "PagerDuty Change Event step";
+    }
+  }
+
+  public static class PagerDutyChangeEventExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+    private static final long serialVersionUID = 1L;
+
+    @StepContextParameter
+    private transient Run<?, ?> build;
+
+    @Inject
+    transient PagerDutyChangeEventStep step;
+
+    @StepContextParameter
+    transient TaskListener listener;
+
+    @Override
+    protected Void run() {
+      new ChangeEventSender().send(step.integrationKey, build, listener);
+      return null;
+    }
+  }
+}

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/config.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Integration Key" field="integrationKey">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="Create Change Event on SUCCESS" field="createOnSuccess">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Create Change Event on FAILURE" field="createOnFailure">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Create Change Event on UNSTABLE" field="createOnUnstable">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Create Change Event on ABORTED" field="createOnAborted">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Create Change Event on NOT_BUILT" field="createOnNotBuilt">
+        <f:checkbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnAborted.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnAborted.html
@@ -1,0 +1,3 @@
+<div>
+  Create a PagerDuty Change Event if the job ends as ABORTED.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnFailure.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnFailure.html
@@ -1,0 +1,3 @@
+<div>
+  Create a PagerDuty Change Event if the job ends as FAILURE.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnNotBuilt.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnNotBuilt.html
@@ -1,0 +1,3 @@
+<div>
+  Create a PagerDuty Change Event if the job ends as NOT_BUILT.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnSuccess.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnSuccess.html
@@ -1,0 +1,3 @@
+<div>
+  Create a PagerDuty Change Event if the job ends as SUCCESS.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnUnstable.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-createOnUnstable.html
@@ -1,0 +1,3 @@
+<div>
+  Create a PagerDuty Change Event if the job ends as UNSTABLE.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-integrationKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help-integrationKey.html
@@ -1,0 +1,3 @@
+<div>
+  This is the 32 character Integration Key for an Integration on a Service.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEvents/help.html
@@ -1,0 +1,3 @@
+<div>
+  Create Change Events on PagerDuty services when jobs complete.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.pagerduty.changeevents;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+
+public class ChangeEventTest {
+    final String summary = "Test summary";
+
+    final String source = "Test source";
+
+    final String integrationKey = "Test integration key";
+
+    final Date timestamp = new Date();
+
+    final String linkHref = "https://google.com";
+
+    final String linkText = "Google";
+
+    final ChangeEvent.Link link = new ChangeEvent.Link(linkHref, linkText);
+
+    @Test
+    public void testBuildingChangeEvents() {
+        HashMap<String, String> customDetails = new HashMap<>();
+        customDetails.put("test", "this");
+
+        ChangeEvent changeEvent = new ChangeEvent.Builder().setSummary(summary).setSource(source)
+                .setTimestamp(timestamp).setIntegrationKey(integrationKey).setCustomDetails(customDetails).addLink(link)
+                .build();
+
+        Assert.assertEquals(summary, changeEvent.getSummary());
+        Assert.assertEquals(source, changeEvent.getSource());
+        Assert.assertEquals(timestamp, changeEvent.getTimestamp());
+        Assert.assertEquals(integrationKey, changeEvent.getIntegrationKey());
+        Assert.assertEquals(1, changeEvent.getLinks().size());
+        Assert.assertEquals(linkHref, changeEvent.getLinks().get(0).getHref());
+        Assert.assertEquals(linkText, changeEvent.getLinks().get(0).getText());
+        Assert.assertEquals("this", changeEvent.getCustomDetails().get("test"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventsTest.java
@@ -1,0 +1,33 @@
+package org.jenkinsci.plugins.pagerduty.changeevents;
+
+import hudson.model.FreeStyleProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ChangeEventsTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    final String integrationKey = "Test integration key";
+
+    @Test
+    public void testConfigRoundtrip() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        ChangeEvents before = new ChangeEvents(integrationKey);
+        before.setCreateOnSuccess(true);
+        before.setCreateOnFailure(false);
+        before.setCreateOnAborted(false);
+        before.setCreateOnUnstable(false);
+        before.setCreateOnNotBuilt(false);
+
+        project.getPublishersList().add(before);
+
+        jenkins.submit(jenkins.createWebClient().getPage(project, "configure").getFormByName("config"));
+
+        ChangeEvents after = project.getPublishersList().get(ChangeEvents.class);
+
+        jenkins.assertEqualBeans(before, after,
+                "integrationKey,createOnSuccess,createOnFailure,createOnAborted,createOnUnstable,createOnNotBuilt");
+    }
+}


### PR DESCRIPTION
This change adds a new post-build action to send a change event to PagerDuty when a job completes.