### PR TITLE
adds pipeline dependencies hpi:run installs dependencies automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.190.x</artifactId>
+                <version>10</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.7</version>
@@ -72,7 +80,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -83,6 +90,46 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>display-url-api</artifactId>
             <version>2.3.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>4.5.10-2.0</version>
+        </dependency>
+
+
+        <!-- minimum pipeline plugins required for testing-->
+        <!-- Pipeline: Basic Steps-->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Pipeline: Groovy-->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Pipeline: Nodes and Processes-->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Pipeline: Job-->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Pipeline: Declarative-->
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <version>1.3.5</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Simplify dependency management using the io.jenkins.tools.bom.bom-2.190.x (Build-of-Materials for Jenkins Plugins):

https://github.com/jenkinsci/bom

This allows users to run `mvn hpi:run`, which runs a local jenkins install.  Specifically this pre-installs the pipeline plugins making exploratory testing easier.